### PR TITLE
Release/v0.1.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nett-benchmarks"
-version = "0.1"
+version = "0.15"
 authors = [
   { name="Bhargav Desai", email="desabh@iu.edu" },
 ]
@@ -17,7 +17,6 @@ dependencies = [
     "sb3-contrib==1.8.0",
     "imageio-ffmpeg",
     "torchvision",
-    "scipy",
     "timm",
     "nvidia-ml-py",
     "ipywidgets"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nett-benchmarks"
-version = "0.15"
+version = "0.1.5"
 authors = [
   { name="Bhargav Desai", email="desabh@iu.edu" },
 ]


### PR DESCRIPTION
An intermediate release since a breaking change was made to the library–changing the name of the library import from`netts` to `nett`.

I've also dropped library dependency on scipy. It was previously imported [here](https://github.com/buildingamind/NewbornEmbodiedTuringTest/blob/01f7da86368be2f0b8ad85f309dd851dee787367/src/simulation/env_wrapper/dvs_wrapper.py#L5), but never used. 