### PR TITLE
Hotfix for ML-Agents Registry Issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ readme = "README.md"
 license = {file = "LICENSE"}
 requires-python = "==3.10.12"
 dependencies = [
-    "mlagents==1.0.0",
+    "mlagents_envs @ git+https://github.com/Unity-Technologies/ml-agents@a66ffbf0628e712758eae78d694c09930f1e4545#subdirectory=ml-agents-envs",
+    "mlagents @ git+https://github.com/Unity-Technologies/ml-agents@a66ffbf0628e712758eae78d694c09930f1e4545#subdirectory=ml-agents",
     "stable-baselines3[extra]==1.8.0",
     "sb3-contrib==1.8.0",
     "torchvision",

--- a/src/nett/__init__.py
+++ b/src/nett/__init__.py
@@ -27,7 +27,7 @@ from nett.environment.builder import Environment
 from nett.nett import NETT
 
 # release version
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 # change permissions of the ml-agents binaries directory
 


### PR DESCRIPTION
Changed ML-Agents dependency version to be version of develop that does not have GCP registry issues (see https://github.com/Unity-Technologies/ml-agents/issues/6104).