### PR TITLE
stable dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ To begin benchmarking your first embodied agent with NETT, please be aware:
 
    Configure the learning aspects, including the policy network (e.g. "CnnPolicy"), learning algorithm (e.g. "PPO"), the reward function, and the encoder.
    ```python
-   brain = Brain(policy="CnnPolicy", algorithm="PPO")
+   brain = Brain(policy="CnnPolicy", algorithm="PPO", encoder='small')
    ```
    *(To get a list of all available policies, algorithms, and encoders, run `nett.list_policies()`, `nett.list_algorithms()`, and `nett.list_encoders()` respectively, which requires you to run`import nett` beforehand.)*
 
@@ -141,7 +141,7 @@ To begin benchmarking your first embodied agent with NETT, please be aware:
 
    Set up the agent's physical interface with the environment. It's possible to apply gym.Wrappers for data preprocessing.
    ```python
-   body = Body(type="basic", dvs=False, wrappers=None)
+   body = Body(type="basic", wrappers=None)
    ```
    Here, we do not pass any wrappers, letting information from the environment reach the brain "as is". Alternative body types (e.g. `two-eyed`, `rag-doll`) are planned in future updates.
 
@@ -162,7 +162,7 @@ To begin benchmarking your first embodied agent with NETT, please be aware:
    ```python
    job_sheet = benchmarks.run(output_dir="path/to/run/output/directory/", num_brains=5, train_eps=10, test_eps=5)
    ```
-   The `run` function is asynchronous, returning the list of jobs that may or may not be complete. If you wish to display the Unity environments running, set the `batch_mode` parameter to `False`.
+   The `run` function is asynchronous, returning the list of jobs that may or may not be complete. If you wish to display the Unity environments running, set the `batch_mode` parameter to `False`. 
 
 5. **Check Status**:
 

--- a/nohup.out
+++ b/nohup.out
@@ -1,1 +1,0 @@
-python: can't open file '/home/desabh/phd/NewbornEmbodiedTuringTest/..scripts/debug_binding_latest.py': [Errno 2] No such file or directory

--- a/nohup.out
+++ b/nohup.out
@@ -1,0 +1,1 @@
+python: can't open file '/home/desabh/phd/NewbornEmbodiedTuringTest/..scripts/debug_binding_latest.py': [Errno 2] No such file or directory

--- a/src/nett/brain/__init__.py
+++ b/src/nett/brain/__init__.py
@@ -4,9 +4,7 @@ from pathlib import Path
 
 import stable_baselines3
 import sb3_contrib
-from stable_baselines3.common.torch_layers import BaseFeaturesExtractor
 
-from nett.brain import encoders
 
 def list_encoders() -> list[str]:
     """
@@ -72,6 +70,12 @@ def get_encoder_dict() -> dict[str, str]:
             encoder_class = [node for node in ast.walk(module) if isinstance(node, ast.ClassDef)][0]
             # add to the dictionary
             encoders_dict[module_name] = encoder_class.name
+
+    # add small, medium and large encoders too
+    encoders_dict['small'] = 'defualt'
+    encoders_dict['medium'] = encoders_dict['resnet10']
+    encoders_dict['large'] = encoders_dict['resnet18']
+
     return encoders_dict
 
-encoder_dict = get_encoder_dict()
+encoders_dict = get_encoder_dict()

--- a/src/nett/brain/__init__.py
+++ b/src/nett/brain/__init__.py
@@ -72,7 +72,7 @@ def get_encoder_dict() -> dict[str, str]:
             encoders_dict[module_name] = encoder_class.name
 
     # add small, medium and large encoders too
-    encoders_dict['small'] = 'defualt'
+    encoders_dict['small'] = 'default'
     encoders_dict['medium'] = encoders_dict['resnet10']
     encoders_dict['large'] = encoders_dict['resnet18']
 

--- a/src/nett/brain/builder.py
+++ b/src/nett/brain/builder.py
@@ -1,17 +1,19 @@
 """Module for the Brain class."""
 
+import importlib
 import os
-from typing import Any, Optional
-from pathlib import Path
 import inspect
 import torch
 import stable_baselines3
 import sb3_contrib
 import numpy as np
 import matplotlib.pyplot as plt
+
 from tqdm import tqdm
+from typing import Any, Optional
+from pathlib import Path
 from sb3_contrib import RecurrentPPO
-from stable_baselines3.common.torch_layers import BaseFeaturesExtractor
+from stable_baselines3.common.torch_layers import NatureCNN, BaseFeaturesExtractor
 from stable_baselines3.common.policies import BasePolicy
 from stable_baselines3.common.on_policy_algorithm import OnPolicyAlgorithm
 from stable_baselines3.common.off_policy_algorithm import OffPolicyAlgorithm
@@ -19,10 +21,9 @@ from stable_baselines3.common.env_util import make_vec_env
 from stable_baselines3.common.env_checker import check_env
 from stable_baselines3.common.logger import configure
 from stable_baselines3.common import results_plotter
-from nett.brain import algorithms, policies, encoder_dict
+from nett.brain import algorithms, policies, encoders_dict
 from nett.brain import encoders
 from nett.utils.callbacks import initialize_callbacks
-from gym.wrappers.monitoring.video_recorder import VideoRecorder
 
 # TODO (v0.3): Extend with support for custom policy models
 # TODO (v0.3): should we move validation checks to utils under validations.py?
@@ -54,7 +55,7 @@ class Brain:
         self,
         policy: Any | str,
         algorithm:  str | OnPolicyAlgorithm | OffPolicyAlgorithm,
-        encoder: Any | str = None,
+        encoder: Any | str = 'small',
         embedding_dim: Optional[int] = None,
         reward: str = "supervised",
         batch_size: int = 512,
@@ -75,7 +76,7 @@ class Brain:
         self.algorithm = self._validate_algorithm(algorithm)
         self.policy = self._validate_policy(policy)
         self.train_encoder = train_encoder
-        self.encoder = self._validate_encoder(encoder) if encoder else None
+        self.encoder = self._validate_encoder(encoder)
         self.reward = self._validate_reward(reward) if reward else None
 
         self.embedding_dim = embedding_dim
@@ -120,7 +121,7 @@ class Brain:
         if self.custom_policy_arch:
             policy_kwargs["net_arch"] = self.custom_policy_arch
             
-        self.logger.info(f'Training with {self.algorithm.__name__}')
+        self.logger.info(f'Training {self.encoder.__name__} with {self.algorithm.__name__}')
         try:
             model = self.algorithm(
                 self.policy,
@@ -322,10 +323,14 @@ class Brain:
         """
         # for when encoder is a string
         if isinstance(encoder, str):
-            if encoder not in encoder_dict.keys():
-                raise ValueError(f"If a string, should be one of: {encoder_dict.keys()}")
-            encoder = getattr(encoders, encoder_dict[encoder])
-
+            if encoder in encoders_dict.keys() and encoder != 'small':
+                encoder = getattr(encoders, encoders_dict[encoder])
+            elif encoder == 'small':
+                encoder = NatureCNN
+                encoder.__name__ = 'NatureCNN'
+            else:
+                raise ValueError(f"If a string, should be one of: {encoders_dict.keys()}")
+            
         # for when encoder is a custom PyTorch encoder
         if isinstance(encoder, BaseFeaturesExtractor):
             # TODO (v0.3) pass dummy torch.tensor on "meta" device to validate embedding dim

--- a/src/nett/brain/builder.py
+++ b/src/nett/brain/builder.py
@@ -323,11 +323,11 @@ class Brain:
         """
         # for when encoder is a string
         if isinstance(encoder, str):
-            if encoder in encoders_dict.keys() and encoder != 'small':
-                encoder = getattr(encoders, encoders_dict[encoder])
-            elif encoder == 'small':
+            if encoder == 'small':
                 encoder = NatureCNN
                 encoder.__name__ = 'NatureCNN'
+            elif encoder in encoders_dict.keys():
+                encoder = getattr(encoders, encoders_dict[encoder])
             else:
                 raise ValueError(f"If a string, should be one of: {encoders_dict.keys()}")
             

--- a/src/nett/nett.py
+++ b/src/nett/nett.py
@@ -102,7 +102,7 @@ class NETT:
 
         # calculate iterations
         iterations: dict[str, int] = {}
-        if mode in ["train", "full"]:
+        if mode in ["train", "full"] or job_memory == "auto": #TODO: auto job_memory runs a train job, requiring iterations["train"] to run:
             iterations["train"] = steps_per_episode * train_eps
         if mode in ["test", "full"]:
             iterations["test"] = test_eps * self.environment.num_test_conditions
@@ -289,10 +289,6 @@ class NETT:
     def _estimate_job_memory(self, devices: list[int], base_port: int) -> int:
         self.logger.info("Estimating memory for a single job")
         try:
-            # create a temporary directory to hold memory estimate during runtime
-            tmp_path = Path("./.tmp/").resolve()
-            tmp_path.mkdir(parents=True, exist_ok=True)
-
             # find the GPU with the most free memory
             free_memory = [nvmlDeviceGetMemoryInfo(nvmlDeviceGetHandleByIndex(device)).free for device in devices]
             most_free_gpu = free_memory.index(max(free_memory))

--- a/src/nett/nett.py
+++ b/src/nett/nett.py
@@ -67,6 +67,7 @@ class NETT:
             steps_per_episode: int = 1000,
             conditions: Optional[list[str]] = None,
             verbose: int = True,
+            synchronous: bool = False,
             save_checkpoints: bool = False,
             checkpoint_freq: int = 30_000,
             base_port: int = 5004) -> list[Future]:
@@ -85,6 +86,7 @@ class NETT:
             buffer (float, optional): The buffer for memory allocation. Defaults to 1.2.
             steps_per_episode (int, optional): The number of steps per episode. Defaults to 1000.
             verbose (int, optional): Whether or not to print info statements. Defaults to True.
+            synchronous (bool, optional): Whether to keep code running in the foreground until completion. Defaults to False.
             save_checkpoints (bool, optional): Whether to save checkpoints during training. Defaults to False.
             checkpoint_freq (int, optional): The frequency at which checkpoints are saved. Defaults to 30_000.
             base_port (int, optional): The base port number to use for communication with the Unity environment. Defaults to 5004.
@@ -143,7 +145,7 @@ class NETT:
 
         # launch jobs
         self.logger.info("Launching")
-        job_sheet = self._launch_jobs(jobs, waitlist, verbose)
+        job_sheet = self._launch_jobs(jobs, synchronous, waitlist, verbose)
 
         # return control back to the user after launching jobs, do not block
         return job_sheet
@@ -354,7 +356,7 @@ class NETT:
         }
         return memory_status
     
-    def _launch_jobs(self, jobs: list[Job], waitlist: list[Job], verbose: bool) -> dict[Future, Job]:
+    def _launch_jobs(self, jobs: list[Job], synchronous: bool, waitlist: list[Job], verbose: bool) -> dict[Future, Job]:
         """
         Launch the jobs in the job sheet.
 
@@ -387,6 +389,13 @@ class NETT:
                     job.port = free_port
                     job_future = executor.submit(self._execute_job, job)
                     job_sheet[job_future] = job
+                    time.sleep(1)
+
+            if synchronous:
+                while job_sheet:
+                    done, _ = future_wait(job_sheet, return_when=FIRST_COMPLETED)
+                    for doneFuture in done:
+                        job_sheet.pop(doneFuture)
                     time.sleep(1)
             
             # close processes and free up resources on completion

--- a/src/nett/utils/job.py
+++ b/src/nett/utils/job.py
@@ -75,6 +75,15 @@ class Job:
       paths[subdir] = Path.joinpath(paths["base"], subdir)
 
     return paths
+  
+  def validation_kwargs(self) -> dict[str, Any]:
+    """Get the environment kwargs for validation
+    """
+    kwargs = self.env_kwargs()
+    kwargs["validation-mode"] = True
+    kwargs["record-chamber"] = False
+    kwargs["record-agent"] = False
+    return kwargs
 
   def env_kwargs(self) -> dict[str, Any]:
     """Get the environment kwargs


### PR DESCRIPTION
This PR is the "stable" version of `nett-benchmarks`, in the sense that it:

1. Makes a couple of bug fixes that broke `dev` even for vanilla use-cases (no jobs start, pipeline breaks at `.run()`)
2. Addresses #109, all jobs complete as expected (even with `save_checkpoints=True`). Running multiple brains with a custom encoder and `save_checkpoints` works as expected.  
3. Address #30, the python multiprocessing pool needs to be manually teared down if calling `ProcessPoolExecutor` without context (not using `with`)
4. Now allows passing either of the `["small", "medium", "large"]` to the `encoder` argument while initializing the `Brain`. The appropriate `encoder` will automatically be picked up. 
For example, 
```
brain = Brain(policy="CnnPolicy", algorithm="PPO", encoder='small')
``` 
5. Fixes a small type in the README, where `dvs` is shown as a valid argument to be passed to `Body` even after removing this behavior